### PR TITLE
Make text visible on light mode terminals

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,8 +74,7 @@ impl Atto {
         }
 
         let paragraph = Paragraph::new(lines.iter().map(|line| Spans::from(Span::raw(line))).collect::<Vec<_>>())
-            .block(block)
-            .style(Style::default().fg(Color::White));
+            .block(block);
         f.render_widget(paragraph, size);
     }
 


### PR DESCRIPTION
Use default foreground color rather than white for text so that its visible on light mode.