### PR TITLE
Update install.sh and README install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,31 +38,12 @@ So after some people used it, here is a list of a few things that people seeming
 
 - syntax highlighting -> possibly tree sitter
 - commands -> no idea how
-- a few people adsked for modes but thats gonna be sidelined
+- a few people asked for modes but thats gonna be sidelined
 
 ### Install:
-
-```curl -fsSL https://raw.githubusercontent.com/m0thman70/Atto/main/install.sh | sh``` 
-
-
-> [!WARNING]
-> Does not update currently installed version.
-
-
-### Compile:
 
 `git clone https://github.com/m0thman70/Atto`
 
 `cd Atto`
 
-`cargo build --release`
-
-`cd target/release`
-
-`chmod +x atto`
-
-`./atto`
-
-and boom you got atto compiled 
-
-if you wanna insall, instead of `cargo build` do `cargo install --path <path>`
+`sudo ./install.sh`

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,10 @@
-#!/bin/bash
 target=target/release/atto
 bin=/usr/bin
 
-cargo build --release
-chmod +x $target
-mv $target $bin
+if [ $(id -u) == 0 ]; then
+  cargo build --release
+  chmod +x $target
+  mv $target $bin
+else
+  echo "install.sh must be run with sudo. Doing nothing."
+fi


### PR DESCRIPTION
Boom! And there we have it. 

Much better install script, and I updated the README. 

Personally I find it quite silly that the README contains instructions to install AND compile. So I removed the compile part, considering that is what the install.sh is doing on hindsight, so I decided to combine two birds with one stone. 

However, my update does not cover how Atto is run, which should be self-explanatory? Would be a good idea to put that section into the README. 